### PR TITLE
support (partial) for nested selectors

### DIFF
--- a/src/postcss-plugin.js
+++ b/src/postcss-plugin.js
@@ -4,6 +4,8 @@ const selectorParser = require("postcss-selector-parser");
 const _ = require("lodash");
 const getFilesListByPatterns = require("./utilities/get-files-list-by-patterns");
 const ReactCSSAnalyzer = require("./react-css-analyzer");
+const SU = require("./selectors-utilities");
+
 
 /**
  * @typedef {Object} Options
@@ -22,12 +24,8 @@ function createTransform(whiteListClasses, rule) {
     const selectorsLength = selectors.length;
 
     selectors.each(selector => {
-      if (selector.length === 1) {
-        if (selector.first.type === "class") {
-          if (!_.includes(whiteListClasses, selector.first.value)) {
-            return selector.parent.remove(selector);
-          }
-        }
+      if (SU.isSupported(selector) && SU.canOmit(selector, whiteListClasses)) {
+        selector.removeSelf();
       }
 
       // Do nothing with unsupported rules

--- a/src/selectors-utilities.js
+++ b/src/selectors-utilities.js
@@ -1,0 +1,46 @@
+const _ = require("lodash");
+
+
+/**
+ * Test if selector supported for
+ * @param  {Selector} selector
+ * @return {boolean}
+ */
+exports.isSupported = function(selector) {
+  const length = selector.length;
+
+  return length > 0 && selector.every((selector, index) => {
+    if (index === 0 || index === (length - 1)) {
+      return selector.type === "class";
+    }
+
+    return (
+      selector.type === "class" ||
+      selector.type === "combinator"
+    );
+  });
+};
+
+/**
+ * Test if selector needed or can be removed later. assumed selector of
+ * supported type.
+ * List of supported selectors:
+ * - .E
+ * - .E .F
+ * - .E > .F
+ * - .E + .F
+ * - .E ~ .F
+ *
+ * @param  {Selector} selector
+ * @param  {string[]} whiteListClasses List of needed classes
+ * @return {boolean}
+ */
+exports.canOmit = function(selector, whiteListClasses = []) {
+  return selector.some(selector => {
+    return (
+      selector.type === "class" &&
+      // NOTE: `!`
+      !_.includes(whiteListClasses, selector.value)
+    );
+  });
+};

--- a/test/postcss-plugin.js
+++ b/test/postcss-plugin.js
@@ -30,44 +30,6 @@ describe("PostCSSPlugin", function() {
     assert.equal(css, ".x{}");
   });
 
-  it("shouldn't remove nested selectors: .x.x", async function() {
-    const result = await postcss([reactCSSOptimizer])
-      .process(".x.y {}", {})
-      .then();
-    const css = result.css.replace(/\s/g, "");
-
-    assert.equal(css, ".x.y{}");
-  });
-
-  describe("parent child relation", function() {
-    it("shouldn't remove: .x > .x", async function() {
-      const result = await postcss([reactCSSOptimizer])
-        .process(".x > .y {}", {})
-        .then();
-      const css = result.css.trim();
-
-      assert.equal(css, ".x > .y {}");
-    });
-
-    it("shouldn't remove: .x > .x > .x", async function() {
-      const result = await postcss([reactCSSOptimizer])
-        .process(".x > .y > .z {}", {})
-        .then();
-      const css = result.css.trim();
-
-      assert.equal(css, ".x > .y > .z {}");
-    });
-
-    it("shouldn't remove: .x .x", async function() {
-      const result = await postcss([reactCSSOptimizer])
-      .process(".x .y {}", {})
-      .then();
-      const css = result.css.trim();
-
-      assert.equal(css, ".x .y {}");
-    });
-  });
-
   describe("or rules (.x, .y)", function() {
     it("should remove all", async function() {
       const result = await postcss([reactCSSOptimizer])

--- a/test/selectors-utilities.js
+++ b/test/selectors-utilities.js
@@ -1,0 +1,176 @@
+/* eslint-env mocha */
+import { assert } from "chai";
+import selectorParser from "postcss-selector-parser";
+import SU from "../src/selectors-utilities";
+
+
+function createSelectorTest(selector, callback) {
+  return () => selectorParser(callback).process(selector);
+}
+
+describe("SelectorsUtilities", function() {
+  describe("isSupported()", function() {
+    describe("supported selectors", function() {
+      it("should return true for `.class` selector", createSelectorTest(".a", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+
+      it("should return true for `.class.class` selector", createSelectorTest(".a.b", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+
+      it("should return true for `.class .class` selector", createSelectorTest(".a .b", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+
+      it("should return true for `.class > .class` selector", createSelectorTest(".a > .b", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+
+      it("should return true for `.class + .class` selector", createSelectorTest(".a + .b", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+
+      it("should return true for `.class ~ .class` selector", createSelectorTest(".a ~ .b", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.ok(result, "result should be true");
+      }));
+    });
+
+    describe("not (yet) supported selectors", function() {
+      it("should return false for `attribute`", createSelectorTest("href", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for `attribute` with value", createSelectorTest("[href='http://com.com']", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for `id`", createSelectorTest("#id", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for `comment`", createSelectorTest("/* comment */", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for empty", createSelectorTest("", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for empty pseudo", createSelectorTest(":hover", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for class with pseudo", createSelectorTest(".x:hover", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for combinator followed empty selector", createSelectorTest("> .x", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+
+      it("should return false for empty selector followed combinator", createSelectorTest(".x >", (rootSelector) => {
+        assert.lengthOf(rootSelector, 1, "number of selector");
+        const result = rootSelector.every(SU.isSupported);
+        assert.notOk(result, "result should be false");
+      }));
+    });
+  });
+
+  describe("canOmit()", function() {
+    it("should work for `.x`", createSelectorTest(".a", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      const falsy  = SU.canOmit(firstSelector, ["a"]);
+      assert.notOk(falsy, ".a shouldn't be omitted");
+
+      const truthy = SU.canOmit(firstSelector, []);
+      assert.ok(truthy, ".a should be omitted");
+    }));
+
+    it("should work for `.x.y`", createSelectorTest(".a.b", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      assert.notOk(SU.canOmit(firstSelector, ["a", "b"]), ".a or .b shouldn't be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["a"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["b"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, []), ".a and .b should be omitted");
+    }));
+
+    it("should work for `.x .y`", createSelectorTest(".a .b", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      assert.notOk(SU.canOmit(firstSelector, ["a", "b"]), ".a or .b shouldn't be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["a"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["b"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, []), ".a and .b should be omitted");
+    }));
+
+    it("should work for `.x > .y`", createSelectorTest(".a > .b", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      assert.notOk(SU.canOmit(firstSelector, ["a", "b"]), ".a or .b shouldn't be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["a"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["b"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, []), ".a and .b should be omitted");
+    }));
+
+    it("should work for `.x + .y`", createSelectorTest(".a + .b", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      assert.notOk(SU.canOmit(firstSelector, ["a", "b"]), ".a or .b shouldn't be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["a"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["b"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, []), ".a and .b should be omitted");
+    }));
+
+    it("should work for `.x ~ .y`", createSelectorTest(".a ~ .b", (rootSelector) => {
+      assert.lengthOf(rootSelector, 1, "number of selector");
+
+      const firstSelector = rootSelector.first;
+
+      assert.notOk(SU.canOmit(firstSelector, ["a", "b"]), ".a or .b shouldn't be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["a"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, ["b"]), ".a and .b should be omitted");
+      assert.ok(SU.canOmit(firstSelector, []), ".a and .b should be omitted");
+    }));
+  });
+});


### PR DESCRIPTION
doesn't include:
.class > element
only
.class > .class

related to #2
